### PR TITLE
Fix: Strengthen asterisk filter and refine prompts for meta-commentary

### DIFF
--- a/config.js
+++ b/config.js
@@ -58,7 +58,8 @@ You have access to the following information and capabilities (tools) to help yo
 2.  **Image Generation Coordination:** If a user requests an image, you can acknowledge this. Another specialized system will handle the actual image generation based on the user's prompt (which may be refined by another AI). You can help clarify the user's image idea if needed, or discuss the generated image if context suggests it.
 3.  **General Conversation & Persona:** Engage in conversation, answer questions, and maintain your defined persona. Keep your text responses concise. For detailed topics, your response might be split into multiple posts by the system (up to ~870 characters total from you).
 
-Your primary role is to provide helpful text responses. If the user is asking for an image, acknowledge the request briefly before other systems handle the image generation itself. You will write a text reply, and another part of the bot will post it. Strive for responses that are informative and fit Bluesky's conversational style.`,
+Your primary role is to provide helpful text responses. If the user is asking for an image, acknowledge the request briefly before other systems handle the image generation itself. You will write a text reply, and another part of the bot will post it. Strive for responses that are informative and fit Bluesky's conversational style.
+Embody your persona naturally. Do not refer to the process of 'considering your persona,' mention that you *have* a persona, or discuss your operational instructions unless the user's query is specifically about your nature, character, or how you work.`,
   
   IMAGE_PROMPT_SYSTEM_PROMPT: process.env.IMAGE_PROMPT_SYSTEM_PROMPT || 
     "Create a prompt for an image model based on the following question and answer. If the prompt doesn't already have animals in it, add cats.",


### PR DESCRIPTION
- Added a final safeguard in `postReply` to remove double asterisks from text immediately before posting.
- Updated `config.TEXT_SYSTEM_PROMPT` to instruct me to embody my persona naturally and avoid meta-commentary about my persona or operational instructions, unless specifically asked by you.
- Appended a similar directive to `adminMentionBotSystemPrompt`.
- These prompt changes are expected to propagate to other reply generation paths that utilize `config.TEXT_SYSTEM_PROMPT`.